### PR TITLE
refactor api authentication

### DIFF
--- a/app/controllers/api/api_application_controller.rb
+++ b/app/controllers/api/api_application_controller.rb
@@ -1,5 +1,4 @@
 class Api::ApiApplicationController < ActionController::API
-  before_action :authenticate_user!
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   protected

--- a/app/controllers/api/learning_units_controller.rb
+++ b/app/controllers/api/learning_units_controller.rb
@@ -1,6 +1,9 @@
 module Api
   class LearningUnitsController < ApiApplicationController
     before_action :set_learning_unit, only: [:complete_learning_unit]
+    before_action :authenticate_user!,
+                  only: %i[completed complete_learning_unit
+                           uncomplete_learning_unit]
 
     def show
       learning_unit = LearningUnit.find(params[:id])

--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ResourcesController < ApiApplicationController
+    before_action :authenticate_user!, only: %i[evaluate evaluation create]
+
     def show
       resource = Resource.find(params[:id])
       render json: resource

--- a/spec/requests/api/curriculums_spec.rb
+++ b/spec/requests/api/curriculums_spec.rb
@@ -27,10 +27,6 @@ describe 'Curriculums API' do
 
         run_test!
       end
-
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
     end
   end
 
@@ -50,10 +46,6 @@ describe 'Curriculums API' do
                  name: { type: :string }
                }
 
-        run_test!
-      end
-
-      response '401', 'Unauthorized', skip_before: true do
         run_test!
       end
 

--- a/spec/requests/api/cycles_spec.rb
+++ b/spec/requests/api/cycles_spec.rb
@@ -32,10 +32,6 @@ describe 'Cycles API' do
         run_test!
       end
 
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
-
       response '404', 'Curriculum not found' do
         let(:curriculum_id) { 'invalid' }
         run_test!

--- a/spec/requests/api/learning_units_spec.rb
+++ b/spec/requests/api/learning_units_spec.rb
@@ -40,10 +40,6 @@ describe 'Learning Units API' do
         run_test!
       end
 
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
-
       response '404', 'Curriculum not found' do
         let(:curriculum_id) { 'invalid' }
         run_test!
@@ -69,10 +65,6 @@ describe 'Learning Units API' do
                  image_url: { type: :string, nullable: true }
                }
 
-        run_test!
-      end
-
-      response '401', 'Unauthorized', skip_before: true do
         run_test!
       end
 

--- a/spec/requests/api/resource_evaluations_spec.rb
+++ b/spec/requests/api/resource_evaluations_spec.rb
@@ -36,10 +36,6 @@ describe 'Resource Evaluations API' do
         run_test!
       end
 
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
-
       response '404', 'Resource not found' do
         let(:resource_id) { 'invalid' }
         run_test!

--- a/spec/requests/api/resources_spec.rb
+++ b/spec/requests/api/resources_spec.rb
@@ -34,10 +34,6 @@ describe 'Resources API' do
         run_test!
       end
 
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
-
       response '404', 'Learning Unit not found' do
         let(:learning_unit_id) { 'invalid' }
         run_test!
@@ -63,10 +59,6 @@ describe 'Resources API' do
         run_test!
       end
 
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
-
       response '404', 'Resource not found' do
         let(:id) { 'invalid' }
         run_test!
@@ -89,10 +81,6 @@ describe 'Resources API' do
                properties: {
                  average_evaluation: { type: :string }
                }
-        run_test!
-      end
-
-      response '401', 'Unauthorized', skip_before: true do
         run_test!
       end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -23,10 +23,6 @@ describe 'Users API' do
                }
         run_test!
       end
-
-      response '401', 'Unauthorized', skip_before: true do
-        run_test!
-      end
     end
   end
 end

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -32,9 +32,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }
@@ -74,9 +71,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Curriculum not found"
@@ -125,9 +119,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Curriculum not found"
@@ -185,9 +176,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "404": {
             "description": "Curriculum not found"
           }
@@ -236,9 +224,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Learning Unit not found"
@@ -432,9 +417,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "404": {
             "description": "Resource not found"
           }
@@ -486,9 +468,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Learning Unit not found"
@@ -581,9 +560,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "404": {
             "description": "Resource not found"
           }
@@ -622,9 +598,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Resource not found"
@@ -775,9 +748,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }


### PR DESCRIPTION
This PR moves the `authenticate_user!` action from ApiApplicationController to each endpoint controller that need it. Also, it fixes tests that break after this change.

# Context
- With this PR, we are making public the API endpoints that retrieve public information (curriculums, learning units, cycles, resources, comments, average evaluation). For the endpoints that may alter the database (complete LU, create, evaluate or comment resources) remains the authentication requirement.

# Changelog
- Drop the `:authenticate_user!` before action in the ApiApplicationController
- Put the `:authenticate_user!` before action in the LearningUnit and Resources Controllers for specific endpoints.
- Modify test of API controllers that verify user is authenticated in edited controllers.

# QA
- You can test each endpoint on /api-docs/index.html