### PR TITLE
feat(cycle-learning-units): create endpoint that retrieves a cycle's learning units

### DIFF
--- a/app/controllers/api/learning_units_controller.rb
+++ b/app/controllers/api/learning_units_controller.rb
@@ -8,6 +8,12 @@ module Api
     end
 
     def index
+      cycle = Cycle.find(params[:cycle_id])
+      learning_units = cycle.learning_units
+      render json: learning_units, only: %i[id name description image_url]
+    end
+
+    def curriculum_learning_units
       curriculum = Curriculum.find(params[:curriculum_id])
       learning_units = curriculum.learning_units
       render json: learning_units

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,12 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :curriculums, only: %i[index show] do
-      resources :learning_units, only: %i[index]
+      get 'learning_units', to: 'learning_units#curriculum_learning_units'
       resources :cycles, only: %i[index]
+    end
+
+    resources :cycles, only: %i[] do
+      resources :learning_units, only: %i[index]
     end
 
     resources :learning_units, only: %i[show] do

--- a/spec/requests/api/learning_units_spec.rb
+++ b/spec/requests/api/learning_units_spec.rb
@@ -35,7 +35,7 @@ describe 'Learning Units API' do
                    image_url: { type: :string, nullable: true }
                  }
                },
-               required: %w[id name]
+               required: %w[id name description image_url]
 
         run_test!
       end
@@ -46,6 +46,38 @@ describe 'Learning Units API' do
 
       response '404', 'Curriculum not found' do
         let(:curriculum_id) { 'invalid' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/cycles/{cycle_id}/learning_units' do
+    get 'Returns all Learning Unit from a Cycle' do
+      tags 'Learning Units'
+      produces 'application/json'
+      parameter name: :cycle_id, in: :path, type: :string
+      operationId 'getCycleLearningUnits'
+
+      let(:cycle_id) { create(:cycle, name: 'first cycle').id }
+
+      response '200', 'Success' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   name: { type: :string },
+                   description: { type: :string },
+                   image_url: { type: :string, nullable: true }
+                 }
+               },
+               required: %w[id name description image_url]
+
+        run_test!
+      end
+
+      response '404', 'Cycle not found' do
+        let(:cycle_id) { 'invalid' }
         run_test!
       end
     end

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -179,7 +179,9 @@
                   },
                   "required": [
                     "id",
-                    "name"
+                    "name",
+                    "description",
+                    "image_url"
                   ]
                 }
               }
@@ -190,6 +192,64 @@
           },
           "404": {
             "description": "Curriculum not found"
+          }
+        }
+      }
+    },
+    "/api/cycles/{cycle_id}/learning_units": {
+      "get": {
+        "summary": "Returns all Learning Unit from a Cycle",
+        "tags": [
+          "Learning Units"
+        ],
+        "parameters": [
+          {
+            "name": "cycle_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getCycleLearningUnits",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "image_url": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "image_url"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cycle not found"
           }
         }
       }


### PR DESCRIPTION
# Base PR
PR based on main
# Context
- With this PR, we are adding the endpoint api/cycles/:cycle_id/learning_units to retrieve the list of learning_units of a cycle:
![image](https://user-images.githubusercontent.com/100784837/197337613-049070b4-b767-4265-89c5-3c205fb29a8c.png)
This is part of our first slice of work.

# Changelog
- Create a new route for the endpoint, and a controller to manage it
- Create tests for the endpoint and swagger documentation
# QA
- Make sure of have run the seeds and being logged in
- Go to http://localhost:3000/api/cycles/1/learning_units to see the endpoint output