### PR TITLE
feat(cycle-details-endpoint)

### DIFF
--- a/app/controllers/api/cycles_controller.rb
+++ b/app/controllers/api/cycles_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class CyclesController < ApiApplicationController
     before_action :set_curriculum, only: [:index]
+    before_action :set_cycle, only: [:show]
 
     def index
       cycles = @curriculum.cycles
@@ -8,10 +9,20 @@ module Api
              only: %i[id name learning_goals_description]
     end
 
+    def show
+      render json: @cycle,
+             only: %i[id name order_number learning_goals_description
+                      challenge_description boilerplate_url]
+    end
+
     private
 
     def set_curriculum
       @curriculum = Curriculum.find(params[:curriculum_id])
+    end
+
+    def set_cycle
+      @cycle = Cycle.find(params[:id])
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       resources :cycles, only: %i[index]
     end
 
-    resources :cycles, only: [] do
+    resources :cycles, only: %i[show] do
       resources :learning_units, only: %i[index]
       resources :learning_unit_successions, only: %i[index]
     end

--- a/spec/requests/api/cycles_spec.rb
+++ b/spec/requests/api/cycles_spec.rb
@@ -38,4 +38,37 @@ describe 'Cycles API' do
       end
     end
   end
+
+  path '/api/cycles/{id}' do
+    get 'Returns Cycle details' do
+      tags 'Cycles'
+      description 'Retrieves the details of a cycle'
+      parameter name: :id, in: :path, type: :string
+      produces 'application/json'
+      operationId 'getCycle'
+
+      let(:curriculum_id) { create(:curriculum).id }
+      let(:cycle) { create(:cycle, curriculum_id:) }
+      let(:id) { cycle.id }
+
+      response '200', 'Success' do
+        schema type: :object,
+               properties: {
+                 id: { type: :integer },
+                 name: { type: :string },
+                 order_number: { type: :integer },
+                 learning_goals_description: { type: :string },
+                 challenge_description: { type: :string },
+                 boilerplate_url: { type: :string }
+               }
+
+        run_test!
+      end
+
+      response '404', 'Cycle not found' do
+        let(:id) { 'invalid' }
+        run_test!
+      end
+    end
+  end
 end

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -126,6 +126,61 @@
         }
       }
     },
+    "/api/cycles/{id}": {
+      "get": {
+        "summary": "Returns Cycle details",
+        "tags": [
+          "Cycles"
+        ],
+        "description": "Retrieves the details of a cycle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getCycle",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "order_number": {
+                      "type": "integer"
+                    },
+                    "learning_goals_description": {
+                      "type": "string"
+                    },
+                    "challenge_description": {
+                      "type": "string"
+                    },
+                    "boilerplate_url": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cycle not found"
+          }
+        }
+      }
+    },
     "/api/cycles/{cycle_id}/learning_unit_successions": {
       "get": {
         "summary": "Returns all learning units successions in the cycle",


### PR DESCRIPTION
# Base PR
- PR based on main

# Context
- With this PR, we are adding the endpoint `api/cycles/:id` to retrieve the details of a cycle: 

![image](https://user-images.githubusercontent.com/73831187/197292733-934cba91-70b1-4920-a4e9-44de3c158dfd.png)

This is part of our first slice of work.

# Changelog
- Create a new route for the endpoint, and a controller to manage it
- Create tests for the endpoint and swagger documentation
- It also includes a new API error handler for `ActiveRecord::RecordInvalid`, returning an error 400

# QA
- Make sure of have run the seeds and being logged in
- Go to `http://localhost:3000/api/cycles/1` to see the endpoint output
