### PR TITLE
feat(resources index):  add total number of evaluations of every learning units resource

### DIFF
--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -10,7 +10,7 @@ module Api
     def index
       resources = LearningUnit.find(params[:learning_unit_id])&.resources
       render json: resources, only: %i[id name url],
-             methods: [:average_evaluation]
+             methods: %i[average_evaluation number_of_evaluations]
     end
 
     def average_evaluation

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -23,4 +23,8 @@ class Resource < ApplicationRecord
   def average_evaluation
     resource_evaluations.average(:evaluation)
   end
+
+  def number_of_evaluations
+    resource_evaluations.count(:evaluation)
+  end
 end

--- a/spec/requests/api/resources_spec.rb
+++ b/spec/requests/api/resources_spec.rb
@@ -21,17 +21,23 @@ describe 'Resources API' do
       let(:learning_unit_id) { create(:learning_unit).id }
 
       response '200', 'Success' do
-        schema type: :array,
+        schema: {type: :array,
                items: {
                  type: :object,
                  properties: {
                    id: { type: :integer },
                    name: { type: :string },
-                   url: { type: :string }
-                 }
+                   url: { type: :string },
+                   average_evaluation: { type: :string },
+                   number_of_evaluations: { type: :integer }
+                  }
                },
                required: %w[id name]
-        run_test!
+              }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to match_json_schema(schema)
+        end
       end
 
       response '404', 'Learning Unit not found' do

--- a/spec/requests/api/resources_spec.rb
+++ b/spec/requests/api/resources_spec.rb
@@ -7,7 +7,7 @@ describe 'Resources API' do
   before do |response|
     sign_in user unless response.metadata[:skip_before]
     if response.metadata[:create_evaluation]
-      create(:resource_evaluation, resource:, user:)
+      create(:resource_evaluation, resource:, user:, evaluation: 3)
     end
   end
 
@@ -18,10 +18,12 @@ describe 'Resources API' do
       parameter name: :learning_unit_id, in: :path, type: :string
       operationId 'getLearningUnitResources'
 
-      let(:learning_unit_id) { create(:learning_unit).id }
+      let(:learning_unit) { create(:learning_unit) }
+      let(:learning_unit_id) { learning_unit.id }
+      let(:resource) { create(:resource, learning_unit:) }
 
-      response '200', 'Success' do
-        schema: {type: :array,
+      response '200', 'Success', create_evaluation: true do
+        schema type: :array,
                items: {
                  type: :object,
                  properties: {
@@ -30,13 +32,13 @@ describe 'Resources API' do
                    url: { type: :string },
                    average_evaluation: { type: :string },
                    number_of_evaluations: { type: :integer }
-                  }
+                 }
                },
                required: %w[id name]
-              }
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data).to match_json_schema(schema)
+          expect(data[0]['average_evaluation']).to eq('3.0')
+          expect(data[0]['number_of_evaluations']).to eq(1)
         end
       end
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -636,6 +636,12 @@
                       },
                       "url": {
                         "type": "string"
+                      },
+                      "average_evaluation": {
+                        "type": "string"
+                      },
+                      "number_of_evaluations": {
+                        "type": "integer"
                       }
                     }
                   },


### PR DESCRIPTION
# Base PR
- PR based on main branch. 

# Context
- With this PR, we modify the resource#index action adding the 'number of evaluations' field. 

# Changelog
- Add new model method 'number_of_evaluations' on Resource model
- Call model method on endpoint resources#index
- Modify Rspec test on number_of_evaluations and average_evaluation (that was not implemented). 

# QA
- Launch Backend App
- Enter to localhost:3000
- Go to http://localhost:3000/api/learning_units/1/resources
- Check if it returns the corresponding average_evaluation and number_of_evaluations.

