### PR TITLE
Redirect after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,3 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-
-  def after_sign_in_path_for(resource)
-    stored_location_for(resource) || root_path
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || root_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,9 @@
+module Users
+  class SessionsController < Devise::SessionsController
+    def new
+      self.resource = resource_class.new(sign_in_params)
+      store_location_for(resource, params[:redirect_to])
+      super
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,5 +5,9 @@ module Users
       store_location_for(resource, params[:redirect_to])
       super
     end
+
+    def after_sign_in_path_for(resource)
+      stored_location_for(resource) || root_path
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount Rswag::Api::Engine => '/api-docs'
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'users/sessions' }
 
   resources :resources, only: %i[show] do
     resources :resource_comments, only: %i[create]

--- a/spec/requests/users/sessions_controller_spec.rb
+++ b/spec/requests/users/sessions_controller_spec.rb
@@ -6,27 +6,21 @@ RSpec.describe Users::SessionsController, type: :request do
     let(:curriculum_id) { create(:curriculum).id }
 
     context 'when redirect_to is not present as parameter' do
-      def perform
+      it 'redirects to the root_path' do
         sign_in user
         post user_session_url
-      end
-
-      it 'redirects to the root_path' do
-        expect(perform).to redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
     context 'when redirect is present as parameter' do
-      def perform(redirect_path)
-        get new_user_session_path, params: { redirect_to: redirect_path }
-        sign_in user
-        post user_session_url
-      end
-
       let(:redirect_path) { "/curriculums/#{curriculum_id}/learning_units" }
 
       it 'redirects to the provided path' do
-        expect(perform(redirect_path)).to redirect_to(redirect_path)
+        get new_user_session_path, params: { redirect_to: redirect_path }
+        sign_in user
+        post user_session_url
+        expect(response).to redirect_to(redirect_path)
       end
     end
   end

--- a/spec/requests/users/sessions_controller_spec.rb
+++ b/spec/requests/users/sessions_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Users::SessionsController, type: :request do
+  describe 'Sign-in redirect_to' do
+    let(:user) { create(:user) }
+    let(:curriculum_id) { create(:curriculum).id }
+
+    context 'when redirect_to is not present as parameter' do
+      def perform
+        sign_in user
+        post user_session_url
+      end
+
+      it 'redirects to the root_path' do
+        expect(perform).to redirect_to(root_path)
+      end
+    end
+
+    context 'when redirect is present as parameter' do
+      def perform(redirect_path)
+        get new_user_session_path, params: { redirect_to: redirect_path }
+        sign_in user
+        post user_session_url
+      end
+
+      let(:redirect_path) { "/curriculums/#{curriculum_id}/learning_units" }
+
+      it 'redirects to the provided path' do
+        expect(perform(redirect_path)).to redirect_to(redirect_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context
With this PR, we are making possible to set a page to which redirect after sign-in.
 By now, after signing-in, a user is always redirected to the same `root_path` (landing page or home).  As we are making the site publicly available, a user could decide to sign in while visiting any page, for example `/learning-units/3`. The desired behavior is that after signing-in, the user should be redirected to the page she was visiting before (`/learning-units/3`). 

To set the redirection page, you have to add a query param `redirect_to` (with a valid path) to the sign-in path, for example:
```
/users/sign_in?redirect_to=/learning-units/3
```
will redirect to `/learning-units/3` after a successful sign-in.

# Changelog
- Creates a new file `sessions_controller.rb` which manage the storing of the ´redirect_to´ parameter.
- Add rspec test for ´sessions_controller´

# QA
- Run docker container of the Rails app
- Run the frontend server
- You should be logged out
- go to `http://localhost:3001/users/sign_in?redirect_to=/learning-units/3` and sign-in
- You should be automatically redirected to page `http://localhost:3001/learning-units/3`
- Try changing `/learning-units/3` with other values and check if correctly redirected.

