### PR TITLE
Feat successions admin section

### DIFF
--- a/app/admin/cycle_learning_units.rb
+++ b/app/admin/cycle_learning_units.rb
@@ -1,0 +1,5 @@
+ActiveAdmin.register CycleLearningUnit do
+  belongs_to :cycle
+  navigation_menu :cycle
+  permit_params :learning_unit
+end

--- a/app/admin/cycles.rb
+++ b/app/admin/cycles.rb
@@ -1,0 +1,17 @@
+ActiveAdmin.register Cycle do
+  permit_params :curriculum,
+                :name,
+                :order_number,
+                :learning_goals_description,
+                :challenge_description,
+                :boilerplate_url
+
+  sidebar 'Learning Unit Successions', only: %i[show edit] do
+    ul do
+      li link_to 'Learning Unit Successions',
+                 admin_cycle_learning_unit_successions_path(resource)
+      li link_to 'Cycle Learning Units',
+                 admin_cycle_cycle_learning_units_path(resource)
+    end
+  end
+end

--- a/app/admin/learning_unit_successions.rb
+++ b/app/admin/learning_unit_successions.rb
@@ -1,0 +1,14 @@
+ActiveAdmin.register LearningUnitSuccession do
+  belongs_to :cycle
+  navigation_menu :cycle
+  permit_params :predecessor_id, :successor_id, :cycle_id
+
+  form do |f|
+    f.inputs "Cycle #{cycle.name}" do
+      f.input :cycle, as: :hidden, collection: cycle
+      f.input :predecessor, as: :select, collection: cycle.learning_units
+      f.input :successor, as: :select, collection: cycle.learning_units
+    end
+    f.actions
+  end
+end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -16,4 +16,5 @@ class Cycle < ApplicationRecord
   belongs_to :curriculum
   has_many :cycle_learning_units
   has_many :learning_units, through: :cycle_learning_units
+  has_many :learning_unit_successions
 end

--- a/app/models/learning_unit_succession.rb
+++ b/app/models/learning_unit_succession.rb
@@ -17,7 +17,7 @@ class LearningUnitSuccession < ApplicationRecord
 
   def learning_units_must_belong_to_cycle
     return if (
-      [predecessor, successor] - (cycle.present? ? cycle.learning_units : [])
+      [predecessor, successor] - (cycle&.learning_units.presence || [])
     ).empty?
 
     errors.add(:cycle, 'Learning units must belong to the cycle')

--- a/app/models/learning_unit_succession.rb
+++ b/app/models/learning_unit_succession.rb
@@ -3,14 +3,23 @@ class LearningUnitSuccession < ApplicationRecord
   belongs_to :successor, class_name: 'LearningUnit'
   belongs_to :cycle
 
-  validate :different_learning_units_for_succession
   validates :cycle, presence: true
   validates :predecessor, presence: true
   validates :successor, presence: true
+  validate :different_learning_units_for_succession,
+           :learning_units_must_belong_to_cycle
 
   def different_learning_units_for_succession
     return unless predecessor == successor
 
     errors.add(:successor, 'Successor has to be different than predecessor')
+  end
+
+  def learning_units_must_belong_to_cycle
+    return if (
+      [predecessor, successor] - (cycle.present? ? cycle.learning_units : [])
+    ).empty?
+
+    errors.add(:cycle, 'Learning units must belong to the cycle')
   end
 end

--- a/spec/factories/learning_unit_succession.rb
+++ b/spec/factories/learning_unit_succession.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :learning_unit_succession do
     association :cycle, factory: :cycle
-    predecessor { create(:learning_unit) }
-    successor { create(:learning_unit) }
+    predecessor { create(:learning_unit, cycles: [cycle]) }
+    successor { create(:learning_unit, cycles: [cycle]) }
   end
 end

--- a/spec/models/learning_unit_succession_spec.rb
+++ b/spec/models/learning_unit_succession_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe LearningUnitSuccession, type: :model do
   end
 
   describe 'validations' do
-    let(:learning_unit) { create(:learning_unit) }
+    let(:cycle) { create(:cycle) }
+    let(:predecessor) { create(:learning_unit, cycles: [cycle]) }
+    let(:successor) { create(:learning_unit, cycles: [cycle]) }
 
     it { is_expected.to validate_presence_of(:cycle) }
 
@@ -18,9 +20,17 @@ RSpec.describe LearningUnitSuccession, type: :model do
 
     it do
       expect do
-        FactoryBot.create(:learning_unit_succession,
-                          predecessor: learning_unit,
-                          successor: learning_unit)
+        FactoryBot.create(
+          :learning_unit_succession, cycle:, predecessor: successor, successor:
+        )
+      end.to raise_error ActiveRecord::RecordInvalid
+    end
+
+    it do
+      expect do
+        FactoryBot.create(
+          :learning_unit_succession, predecessor:, successor:
+        )
       end.to raise_error ActiveRecord::RecordInvalid
     end
   end

--- a/spec/requests/api/learning_unit_successions_controller_spec.rb
+++ b/spec/requests/api/learning_unit_successions_controller_spec.rb
@@ -5,9 +5,9 @@ describe 'Learning Unit Successions API' do
   let!(:user) { create(:user) }
   let(:curriculum) { create(:curriculum) }
   let(:cycle) { create(:cycle) }
-  let(:first_learning_unit) { create(:learning_unit) }
-  let(:second_learning_unit) { create(:learning_unit) }
-  let(:third_learning_unit) { create(:learning_unit) }
+  let!(:first_learning_unit) { create(:learning_unit, cycles: [cycle]) }
+  let!(:second_learning_unit) { create(:learning_unit, cycles: [cycle]) }
+  let!(:third_learning_unit) { create(:learning_unit, cycles: [cycle]) }
 
   before do |response|
     create(


### PR DESCRIPTION
# Context
- With this PR, we are creating the Admin section for administrators to be able to create learning unit successions between the learning units of a cycle.

# Changelog
- Add a validation to LearningUnitSuccession model to check that the learning units assigned as predecessor and successor belong to the corresponding cycle.
- Add the attribute `has_many` learning units to Cycle model.
- Create cycle's admin section, which will nest the learning unit successions' section.
- Create learning unit successions admin section.
- Create the cycle learning units' admin section, also nested in cycle's section.
- Fixed the learning unit successions factory to create successions that comply with the new model validation, that is, that the learning units belong to the cycle.
- Add a test for the new LearningUnitSuccession model validation.
- Fixed the successions endpoint test, which was failing due to the new validation.

# QA
- Launch your backend application
- Go to localhost:3000/admin
- Login with the admin credentials (specified in the seeds.rb file)
- Go to cycle's section and enter to a cycle's view
- At your right side, you'll have a sidebar with the links to both learning unit successions and cycle learning units' sections.
- Test that you can see the existing successions and create some more. 
- Create a new cycle learning unit (relate a learning unit to a cycle) and then check that it is displayed in the dropdown menu when you want to create a learning unit succession for this cycle.
- You can also test the validation of predecessor and successor not being the same when creating a learning unit succession.
