### PR TITLE
Modify cycle lus

### DIFF
--- a/app/controllers/api/learning_units_controller.rb
+++ b/app/controllers/api/learning_units_controller.rb
@@ -12,8 +12,7 @@ module Api
 
     def index
       cycle = Cycle.find(params[:cycle_id])
-      prepared_data = prepare_data(cycle.learning_units)
-      render json: prepared_data
+      render json: learning_units_with_complition_status(cycle)
     end
 
     def curriculum_learning_units
@@ -63,21 +62,17 @@ module Api
       @learning_unit = LearningUnit.find(params[:learning_unit_id])
     end
 
-    def prepare_data(learning_units)
-      learning_units.map do |learning_unit|
-        {
-          id: learning_unit.id,
-          name: learning_unit.name,
-          description: learning_unit.description,
-          image_url: learning_unit.image_url,
-          completed: completed?(learning_unit)
-        }
+    def learning_units_with_complition_status(cycle)
+      cycle.learning_units.map do |learning_unit|
+        learning_unit_data = learning_unit.as_json
+        learning_unit_data['completed'] = marked_as_completed?(learning_unit)
+        learning_unit_data
       end
     end
 
-    def completed?(learning_unit)
+    def marked_as_completed?(learning_unit)
       user = current_user
-      CompletedLearningUnit.find_by(user:, learning_unit:) ? true : false
+      CompletedLearningUnit.exists?(user:, learning_unit:)
     end
 
     def bad_request

--- a/app/controllers/api/learning_units_controller.rb
+++ b/app/controllers/api/learning_units_controller.rb
@@ -12,8 +12,8 @@ module Api
 
     def index
       cycle = Cycle.find(params[:cycle_id])
-      learning_units = cycle.learning_units
-      render json: learning_units, only: %i[id name description image_url]
+      prepared_data = prepare_data(cycle.learning_units)
+      render json: prepared_data
     end
 
     def curriculum_learning_units
@@ -61,6 +61,37 @@ module Api
 
     def set_learning_unit
       @learning_unit = LearningUnit.find(params[:learning_unit_id])
+    end
+
+    def prepare_data(learning_units)
+      learning_units.map do |learning_unit|
+        {
+          id: learning_unit.id,
+          name: learning_unit.name,
+          description: learning_unit.description,
+          image_url: learning_unit.image_url,
+          completed: completed?(learning_unit)
+        }
+      end
+    end
+
+    def completed?(learning_unit)
+      user = current_user
+      CompletedLearningUnit.find_by(user:, learning_unit:) ? true : false
+    end
+
+    def bad_request
+      status = :bad_request
+      code = 400
+      message = 'Bad Request'
+      render json: { status:, code:, message: }, status:
+    end
+
+    def not_found
+      status = :not_found
+      code = 404
+      message = 'Record_not_found'
+      render json: { status:, code:, message: }, status:
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,7 +97,7 @@ article = Label.create(name: "Article", description: "Is an article")
 
 
 [github, ruby_udemy, react_redux].each do |resource|
-  ResourceLabel.create(resource: resource, label_id: paid)
+  ResourceLabel.create(resource: resource, label: paid)
 end
 
 [github, ruby_udemy, rails_ten, react_redux].each do |resource|

--- a/spec/requests/api/learning_units_controller_spec.rb
+++ b/spec/requests/api/learning_units_controller_spec.rb
@@ -64,7 +64,8 @@ describe 'Learning Units API' do
                    id: { type: :integer },
                    name: { type: :string },
                    description: { type: :string },
-                   image_url: { type: :string, nullable: true }
+                   image_url: { type: :string, nullable: true },
+                   completed: { type: :boolean }
                  }
                },
                required: %w[id name description image_url]

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -344,6 +344,9 @@
                       "image_url": {
                         "type": "string",
                         "nullable": true
+                      },
+                      "completed": {
+                        "type": "boolean"
                       }
                     }
                   },


### PR DESCRIPTION
# Base PR
- PR based Main

# Context
- With this PR, we are including the completed? attribute to the api/cycles/id/learning_units endpoint. This, among other things, will allow the cycle's graph to reflect the status of a learning unit. 

# Changelog
- Create method "completed" in LUs api controller
- Add completed to the json response in the LUs index api controller

# QA
- Access http://localhost:3000/api/cycles/1/learning_units

