### PR TITLE
Feat: name in sign up

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,8 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :configure_permitted_parameters, only: [:create]
+  # rubocop:enable Rails/LexicallyScopedActionFilter
+
   def update_resource(resource, params)
     if resource.provider == 'google_oauth2' || resource.provider == 'github'
       params.delete('current_password')
@@ -8,5 +12,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     else
       resource.update_with_password(params)
     end
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ApplicationRecord
   has_many :user_cycle_states
   has_many :completed_resources
 
+  validates :name, presence: true
+
   def self.from_omniauth(access_token)
     where(provider: access_token.provider,
           oauth_id: access_token.oauth_id).first_or_create do |user|

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex-container">
-  <div class="form-container"> 
+  <div class="form-container">
 
     <h2 class="text-title">Nueva cuenta 💙</h2>
 
@@ -9,6 +9,11 @@
       <div>
         <%= f.label :email, class:"text-label" %><br />
         <%= f.email_field :email, autocomplete: "email", class:"input-form" %>
+      </div>
+
+      <div>
+        <%= f.label "Nombre", class:"text-label" %><br />
+        <%= f.text_field :name, autocomplete: "name", class:"input-form" %>
       </div>
 
       <div>

--- a/db/migrate/20221108184808_user_name_not_null.rb
+++ b/db/migrate/20221108184808_user_name_not_null.rb
@@ -1,0 +1,5 @@
+class UserNameNotNull < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :users, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_05_194703) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_184808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -172,7 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_05_194703) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe User, type: :model do
       expect(build(:user)).to be_valid
     end
   end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 end


### PR DESCRIPTION
# Base PR
- PR based on main branch

# Context
- With this PR, we are resolving the issue of signing up without a name. This brought problems in some components that needed the name to render specific user's stuff, like their resource_comments.

# Changelog
- Add name presence validation to user model
- Create migration to validate it in a database level
- Test that the validation works
- Change on devise registration controller to permit registration to include name field
- Add input field in the sign up form

# QA
- Go to http://localhost:3001/users/sign_up
- Try to sign-up with a non-existing email, without handling a name. An error should appear.
- Try to sign-up with a non-existing email, passing a name. Use the platform, and check, for example, if creating resources and commenting on resources work properly.

