### PR TITLE
feat(redirect-signup): redirect to curriculum path after sign up

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_permitted_parameters, only: [:create]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
+  def new
+    self.resource = resource_class.new(sign_up_params)
+    store_location_for(resource, params[:redirect_to])
+    super
+  end
+
   def update_resource(resource, params)
     if resource.provider == 'google_oauth2' || resource.provider == 'github'
       params.delete('current_password')


### PR DESCRIPTION
This PR manage to redirect to /curriculum/1 after signing in and signing up from landing.
It depends on the approval of the PR # 45 in the frontend.

To test, you can sign in and sign up from the landing page and you will be redirected to `/curriculums/1`