### PR TITLE
refactor: change assets path for public url

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="flex-container">
-  <div class="form-container">
-
+  <div class="form-container"> 
+    <p class="text-header">ser.dev</p>
     <h2 class="text-title">Nueva cuenta 💙</h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
@@ -65,11 +65,18 @@
     touch-action: manipulation;
   }
 
-  .text-title {
-    margin-top: 30px;
-    margin-bottom: 40px;
-    font-weight: bold;
+  .text-header {
     font-size: 2.2em;
+    color: #212B70;
+    margin-top: 20px;
+    margin-bottom: 2px;
+    font-weight: bold;
+  }
+
+  .text-title {
+    margin-top: 5px;
+    margin-bottom: 25px;
+    font-size: 1.4em;
   }
 
   .text-label {

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -41,7 +41,7 @@
 
   .flex-container {
     height: 100%;
-    margin-top: 100px;
+    margin-top: 60px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -111,7 +111,7 @@
     cursor: pointer;
     font-family: Montserrat,sans-serif;
     font-size: .9em;
-    margin: 10px 0px 30px 5px;
+    margin: 10px 0px 20px 5px;
     padding: 10px 15px;
     text-align: center;
     user-select: none;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -33,7 +33,7 @@
 
   .flex-container {
     height: 100%;
-    margin-top: 100px;
+    margin-top: 90px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <div class="flex-container">
   <div class="form-container"> 
-    <h2 class="text-title">Inicio de sesión 🎮</h2>
+    <p class="text-header">ser.dev</p>
+    <h2 class="text-title">Inicio de sesión</h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div >
@@ -56,11 +57,18 @@
     touch-action: manipulation;
   }
 
-  .text-title {
-    margin-top: 30px;
-    margin-bottom: 40px;
-    font-weight: bold;
+  .text-header {
     font-size: 2.2em;
+    color: #212B70;
+    margin-top: 20px;
+    margin-bottom: 2px;
+    font-weight: bold;
+  }
+
+  .text-title {
+    margin-top: 5px;
+    margin-bottom: 25px;
+    font-size: 1.4em;
   }
 
   .text-label {

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -9,7 +9,7 @@
         method: :post,
         class:"#{provider}-form",
         data: {turbo: "false"} do |f| %>
-          <%= f.submit type: "image", src: url_for("#{provider}" == "google_oauth2" ? "/assets/btn_google.svg" : "/assets/btn_github.png"),
+          <%= f.submit type: "image", src: url_for("https://raw.githubusercontent.com/fintual-oss/paraffin-back/main/app/assets/images/#{"#{provider}" == "google_oauth2" ? "btn_google.svg" : "btn_github.png" }"),
             class:"#{provider}-icon"%>
           <%= f.submit  "Sign in with #{"#{provider}" == "google_oauth2" ? "Google" : "GitHub" }",
             class:"#{provider}-text"%>


### PR DESCRIPTION
# Base PR
- PR based on main

# Context
- With this PR, we are "solving" the problem of assets in production. There is now a public url pointing to the project's github repository.
- Please if you have a decent solution let me know, I'm not happy with this solution :(

# Changelog
- Change asset paths to public urls in devise view
- Add a new header for auth views

# QA
- Go to http://localhost:3001/users/sign_in

How it looks (prod)

<img width="670" alt="image" src="https://user-images.githubusercontent.com/42187168/200732993-886e883e-a6c7-4bf4-98f8-1ea9c8562c92.png">

How it should look

<img width="662" alt="image" src="https://user-images.githubusercontent.com/42187168/200846692-b83c64b7-a633-4e44-9021-920cd0c3e5de.png">



